### PR TITLE
✨ Use os.path.isdir for #13

### DIFF
--- a/main.py
+++ b/main.py
@@ -74,7 +74,7 @@ def get_and_save_the_paste(the_target, pastebin_url, pastebin_ref, find_file_nam
     :return: Nothing.
     """
     the_path = "pastes/" + the_target
-    if not os.path.exists(the_path):
+    if not os.path.isdir(the_path):
         os.makedirs(the_path)
     # Download the paste
     raw_html = simple_get(pastebin_url)


### PR DESCRIPTION
This PR adjusts `get_and_save_the_paste()` to use `os.path.isdir` instead of `os.path.exists`. This permits **Pastebin Bisque** to work well on Windows without sacrificing functionality on other OSs. I tested this with Python 3.11 via [Chocolatey](https://chocolatey.org/).

Thank you @11ph22il for opening the :bug:  bug report!